### PR TITLE
Remove deprecated UCI_AnalyseMode option

### DIFF
--- a/uci-analyser/engine.cpp
+++ b/uci-analyser/engine.cpp
@@ -120,8 +120,8 @@ bool Engine::initEngine(int variations, int searchDepth, int searchMaxTime, int 
 
 	send("uci");
     if (waitForResponse("uciok")) {
-        // Set default options.
-        setOption("UCI_AnalyseMode", "true");
+        // Set default options. Recent Stockfish versions no longer
+        // support the UCI_AnalyseMode option, so we only set MultiPV.
         setOption("MultiPV", variations);
 
         // Set command-line options.


### PR DESCRIPTION
## Summary
- remove `UCI_AnalyseMode` from engine initialization
- note in comment that Stockfish no longer supports it

## Testing
- `make`
- `./analyse --engine /usr/games/stockfish --searchdepth 1 example.pgn`

------
https://chatgpt.com/codex/tasks/task_e_68405ac43aa08332a48a9188679af033